### PR TITLE
Change rpcResponse type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# kodi\_jsonrpc
+# kodijsonrpc
 [![GoDoc](https://godoc.org/github.com/StreamBoat/kodi_jsonrpc?status.svg)](http://godoc.org/github.com/StreamBoat/kodi_jsonrpc) ![License-MIT](http://img.shields.io/badge/license-MIT-red.svg)
 ```go
 import "github.com/StreamBoat/kodi_jsonrpc"
 ```
 
-Package `kodi_jsonrpc` provides an interface for communicating with a Kodi/XBMC
+Package `kodijsonrpc` provides an interface for communicating with a Kodi/XBMC
 server via the raw JSON-RPC socket
 
 Extracted from the kodi-callback-daemon.

--- a/kodijsonrpc.go
+++ b/kodijsonrpc.go
@@ -1,10 +1,10 @@
-// Package kodi_jsonrpc provides an interface for communicating with a Kodi/XBMC
+// Package kodijsonrpc provides an interface for communicating with a Kodi/XBMC
 // server via the raw JSON-RPC socket
 //
 // Extracted from the kodi-callback-daemon.
 //
 // Released under the terms of the MIT License (see LICENSE).
-package kodi_jsonrpc
+package kodijsonrpc
 
 import (
 	"encoding/json"

--- a/kodijsonrpc_test.go
+++ b/kodijsonrpc_test.go
@@ -1,4 +1,4 @@
-package kodi_jsonrpc
+package kodijsonrpc
 
 import "fmt"
 


### PR DESCRIPTION
Sometimes Kodi sends a list of results (for example the lists of players returned by the Player.GetActivePlayers method).

Can you consider this change (or another) so that the library can handle these results?

This patch turns Result into an interface so that the JSON decoder can unmarshal the lists of results.  This slightly breaks the API but this is the less intrusive change I could think of...